### PR TITLE
Change vertical arrow caps

### DIFF
--- a/src/tixi/items.cljs
+++ b/src/tixi/items.cljs
@@ -20,11 +20,11 @@
     (case edge
       :start
       (if (= (direction item) "vertical")
-        (if (g/flipped-by-y? (:input item)) "v" "^")
+        (if (g/flipped-by-y? (:input item)) "∨" "∧")
         (if (g/flipped-by-x? (:input item)) ">" "<"))
       :end
       (if (= (direction item) (if (rect-line? item) "horizontal" "vertical"))
-        (if (g/flipped-by-y? (:input item)) "^" "v")
+        (if (g/flipped-by-y? (:input item)) "∧" "∨")
         (if (g/flipped-by-x? (:input item)) "<" ">")))))
 
 (defn- replace-char-in-cache! [item cache i chr]


### PR DESCRIPTION
Using logical OR and AND to make vertical arrows appearance more symmetrical
![screenshot 2015-02-12 19 22 22](https://cloud.githubusercontent.com/assets/1506905/6179976/d54cfbca-b2ec-11e4-8b0a-159b43ad002b.png)

