### PR TITLE
Let the delete key delete

### DIFF
--- a/src/tixi/dispatcher.cljs
+++ b/src/tixi/dispatcher.cljs
@@ -43,6 +43,9 @@
       8  (do ; backspace
            (.preventDefault event)
            (c/keypress :delete))
+      46  (do ; delete
+           (.preventDefault event)
+           (c/keypress :delete))
       67 (when (or (.-metaKey event) (.-ctrlKey event))
            (c/keypress :copy)) ; c
       76 (c/keypress :line) ; l


### PR DESCRIPTION
Delete is keycode 46

I noticed backspace (keycode 8) was mapped to delete elements.

This PR seeks to let delete do the same.

If there's a way to have the switch match both case 8 and 46 and execute the same code, please help by suggesting what that looks like.

closes #11 